### PR TITLE
FIX : add the missing default configuration value, so that psc-extract may easily be run from sources.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,4 @@ spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 secpsc.environment=default
 
+pscextract.mail.receiver=nobody@nowhere.example.com


### PR DESCRIPTION
Closes #31 